### PR TITLE
Fix first run error

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Use [`pip`](https://pypi.org/project/pip/) to install:
 - [colorz](https://github.com/metakirby5/colorz)
 - [haishoku](https://github.com/LanceGin/haishoku)
 
+[PowerShell-Core](https://github.com/powershell/powershell/) `winget install -e Microsoft.PowerShell`
+
+Note: PowerShell versions less that 6 don't support JSON with comments
+
 ```powershell
 winget install Python.Python
 pip install pywal

--- a/winwal.psm1
+++ b/winwal.psm1
@@ -75,7 +75,7 @@ function Update-WalTerminal {
     }
 
     # Load existing profile
-    $configData = (Get-Content -Path $terminalProfile | ConvertFrom-Json)[0]
+    $configData = (Get-Content -Path $terminalProfile | ConvertFrom-Json) | Where-Object { $_ -ne $null }
 
     # Create a new list to store schemes
     $schemes = New-Object Collections.Generic.List[Object]

--- a/winwal.psm1
+++ b/winwal.psm1
@@ -67,12 +67,15 @@ function Update-WalCommandPrompt {
 }
 
 function Update-WalTerminal {
+    $terminalDir = "$HOME/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState"
     $terminalProfile = "$HOME/AppData/Local/Packages/Microsoft.WindowsTerminal_8wekyb3d8bbwe/LocalState/settings.json"
 
     if (!(Test-Path $terminalProfile)) {
         # We'll probably fail out if we don't return early
         return
     }
+
+    Copy-Item -Path $terminalProfile -Destination "$terminalDir/settings.json.bak"
 
     # Load existing profile
     $configData = (Get-Content -Path $terminalProfile | ConvertFrom-Json) | Where-Object { $_ -ne $null }


### PR DESCRIPTION
It appears the initial run doesn't work correctly since the JSon file contains comments. This is causing an issue where when we read the settings.json file it returns an array where one of the elements is `$null`. It appears to be index `1` contains the settings data if a comment was is in the file, and index `0` contains the data if there were no comments.

Update the README to state PowerShell Core as being required (due to support for json with comments).

- Update to use the non `$null` item as the settings.json data
- Save a backup copy of the settings.json as settings.json.back so users can recover better

Fixes #1 