### PR TITLE
remove IValidateSetValuesGenerator for powershell 5 compatibility and add support for windows terminals installed via scoop

### DIFF
--- a/templates/windows-terminal.json
+++ b/templates/windows-terminal.json
@@ -18,4 +18,4 @@
     "brightWhite": "{color15}",
     "background": "{background}",
     "foreground": "{foreground}"
-  }}
+}}


### PR DESCRIPTION
The default powershell on Windows 10 can't run winwal because of IValidateSetValuesGenerator.
Removing this validator for the backend parameter also provides a better error message.
Before, pwsh complained that the backend was not it the IValidateSetValuesGenerator set. Now, pywal will complain about the missing backend in a user friendly way.

This PR also adds support for windows terminals installed via scoop.